### PR TITLE
[fix]更改长按自动复原

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -126,11 +126,14 @@ export default class DragSortableView extends Component{
                     moveToIndex: touchIndex,
                 }
                 this.isMovePanResponder = true
-                this.isScaleRecovery = setTimeout(()=>{
-                    this.endTouch()
-                },300)
             })
         }
+    }
+
+    releaseTouch = () => {
+        this.isScaleRecovery = setTimeout(()=>{
+            this.endTouch()
+        },300)
     }
 
 
@@ -405,6 +408,7 @@ export default class DragSortableView extends Component{
                                 <TouchableOpacity
                                     activeOpacity = {1}
                                     onLongPress={()=>this.startTouch(index)}
+                                    onPressOut={this.releaseTouch}
                                     onPress={()=>{
                                         if (this.props.onClickItem) {
                                             this.props.onClickItem(this.getOriginalData(),item.data,index)


### PR DESCRIPTION
长按放大，不做move的情况下会自动复原。这种方式不太合理，应该是在`onPressOut`的时候进行复原。