### PR TITLE
Add onPressIn and onPressOut

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -213,6 +213,7 @@ export default class DragSortableView extends Component{
     }
 
     onPressOut () {
+        if (this.props.onPressOut) this.props.onPressOut();
         this.isScaleRecovery = setTimeout(()=> {
             if (this.isMovePanResponder && !this.isHasMove) {
                 this.endTouch()
@@ -368,6 +369,7 @@ export default class DragSortableView extends Component{
                     <TouchableOpacity
                         activeOpacity = {1}
                         delayLongPress={this.props.delayLongPress}
+                        onPressIn={() => { if (this.props.onPressIn) this.props.onPressIn()}}
                         onPressOut={()=> this.onPressOut()}
                         onLongPress={()=>this.startTouch(index)}
                         onPress={()=>{
@@ -402,6 +404,8 @@ DragSortableView.propTypes = {
     sortable: PropTypes.bool,
 
     onClickItem: PropTypes.func,
+    onPressIn: PropTypes.func,
+    onPressOut: PropTypes.func,
     onDragStart: PropTypes.func,
     onDragEnd: PropTypes.func,
     onDataChange: PropTypes.func,


### PR DESCRIPTION
Adds props for onPressIn and onPressOut.
This is useful if you need to disable scrolling in a parent ScrollView before longPress is initiated.