### PR TITLE
Fix items get stuck when item moved back

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -209,7 +209,6 @@ export default class DragSortableView extends Component{
                             toValue: {x: parseInt(itemBelow.originLeft),y: parseInt(itemBelow.originTop)},
                             duration: slideDuration,
                             easing: Easing.out(Easing.quad),
-                            useNativeDriver: true,
                         }
                     ).start(() => {
                         this.movingBelowItemBack = false;

--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -182,6 +182,40 @@ export default class DragSortableView extends Component{
                     }
 
                 })
+            } else if (this.touchCurItem.moveToIndex === this.touchCurItem.index) {
+                    
+                // If item is moved back to initial position, sibling items need to be moved back
+                const itemAbove = this.state.dataSource[this.touchCurItem.index + 1];
+                if (itemAbove && !this.movingAboveItemBack) {
+                    this.movingAboveItemBack = true;
+                    Animated.timing(
+                        itemAbove.position,
+                        {
+                            toValue: {x: parseInt(itemAbove.originLeft),y: parseInt(itemAbove.originTop)},
+                            duration: slideDuration,
+                            easing: Easing.out(Easing.quad),
+                            useNativeDriver: true,
+                        }
+                    ).start( () => {
+                        this.movingAboveItemBack = false;
+                    });
+                }
+                const itemBelow = this.state.dataSource[this.touchCurItem.index - 1];
+                if (itemBelow && !this.movingBelowItemBack) {
+                    this.movingBelowItemBack = true;
+                    Animated.timing(
+                        itemBelow.position,
+                        {
+                            toValue: {x: parseInt(itemBelow.originLeft),y: parseInt(itemBelow.originTop)},
+                            duration: slideDuration,
+                            easing: Easing.out(Easing.quad),
+                            useNativeDriver: true,
+                        }
+                    ).start(() => {
+                        this.movingBelowItemBack = false;
+                    });
+                }
+
             }
 
         }

--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -194,7 +194,6 @@ export default class DragSortableView extends Component{
                             toValue: {x: parseInt(itemAbove.originLeft),y: parseInt(itemAbove.originTop)},
                             duration: slideDuration,
                             easing: Easing.out(Easing.quad),
-                            useNativeDriver: true,
                         }
                     ).start( () => {
                         this.movingAboveItemBack = false;


### PR DESCRIPTION
Fixes issue where items would overlap.
This happened if you dragged an item up(or down) one spot, and dragged it back down.