### PR TITLE
Fix items scale on drop

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -210,14 +210,15 @@ export default class DragSortableView extends Component{
                     toValue: 1,
                     duration: scaleDuration,
                 }
-            ).start()
-            this.touchCurItem.ref.setNativeProps({
-                style: {
-                    zIndex: defaultZIndex,
-                }
+            ).start(() => {
+                this.touchCurItem.ref.setNativeProps({
+                    style: {
+                        zIndex: defaultZIndex,
+                    }
+                })
+                this.changePosition(this.touchCurItem.index,this.touchCurItem.moveToIndex)
+                this.touchCurItem = null
             })
-            this.changePosition(this.touchCurItem.index,this.touchCurItem.moveToIndex)
-            this.touchCurItem = null
         }
     }
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-drag-sort",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Drag and drop sort control for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When an item is dragged it scales up but when it is released it does *not* scale back to normal (see attached screenshot).

This seems due to an error in the `endTouch` method, which is responsible to scale the item back to its normal size. This method starts the animation to scale the item back but then calls the `changePosition` method which triggers a re-render and interrupts the animation.

This MR fixes this bug by moving the call to `changePosition` inside `endTouch` to the completion handler of the animation that scales the item back to normal size.