### PR TITLE
Replace library globals with configurable props

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -6,10 +6,6 @@ const {width} = Dimensions.get('window')
 
 const defaultZIndex = 8
 const touchZIndex = 99
-const maxScale = 1.1
-const minOpacity = 0.8
-const scaleDuration = 100
-const slideDuration = 300
 
 export default class DragSortableView extends Component{
 
@@ -68,8 +64,8 @@ export default class DragSortableView extends Component{
             Animated.timing(
                 this.state.dataSource[touchIndex].scaleValue,
                 {
-                    toValue: maxScale,
-                    duration: scaleDuration,
+                    toValue: this.props.maxScale,
+                    duration: this.props.scaleDuration,
                 }
             ).start(()=>{
                 this.touchCurItem = {
@@ -184,7 +180,7 @@ export default class DragSortableView extends Component{
                             item.position,
                             {
                                 toValue: {x: parseInt(nextItem.originLeft+0.5),y: parseInt(nextItem.originTop+0.5)},
-                                duration: slideDuration,
+                                duration: this.props.slideDuration,
                                 easing: Easing.out(Easing.quad),
                             }
                         ).start()
@@ -208,7 +204,7 @@ export default class DragSortableView extends Component{
                 this.state.dataSource[this.touchCurItem.index].scaleValue,
                 {
                     toValue: 1,
-                    duration: scaleDuration,
+                    duration: this.props.scaleDuration,
                 }
             ).start()
             this.touchCurItem.ref.setNativeProps({
@@ -369,8 +365,8 @@ export default class DragSortableView extends Component{
                         left: item.position.x,
                         top: item.position.y,
                         opacity: item.scaleValue.interpolate({
-                            inputRange:[1,maxScale],
-                            outputRange:[1,minOpacity]
+                            inputRange:[1,this.props.maxScale],
+                            outputRange:[1,this.props.minOpacity]
                         }),
                         transform: [transformObj]
                     }]}>
@@ -433,6 +429,10 @@ DragSortableView.defaultProps = {
     scaleStatus: 'scale',
     fixedItems: [],
     isDragFreely: false,
+    maxScale: 1.1,
+    minOpacity: 0.8,
+    scaleDuration: 100,
+    slideDuration: 300,
 }
 
 const styles = StyleSheet.create({

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-drag-sort",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "Drag and drop sort control for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make `maxScale`, `minOpacity`, `scaleDuration` and `slideDuration` configurable props.

Setting maxScale to 1 effectively disabled item scaling, which is particularly useful when dealing with fixed-width items which would otherwise scale out of the screen.