### PR TITLE
Expose index occupied by currently dragged element to onDragging

### DIFF
--- a/lib/DragSortableView.js
+++ b/lib/DragSortableView.js
@@ -126,10 +126,6 @@ export default class DragSortableView extends Component{
                 y: top,
             })
 
-            if (this.props.onDragging) {
-                this.props.onDragging(gestureState,left,top)
-            }
-
             let moveToIndex = 0
             let moveXNum = dx/this.itemWidth
             let moveYNum = dy/this.itemHeight
@@ -145,6 +141,10 @@ export default class DragSortableView extends Component{
             }
 
             moveToIndex = this.touchCurItem.index+moveXNum+moveYNum*rowNum
+
+            if (this.props.onDragging) {
+                this.props.onDragging(gestureState,left,top,moveToIndex)
+            }
 
             if (moveToIndex > this.state.dataSource.length-1) {
                 moveToIndex = this.state.dataSource.length-1


### PR DESCRIPTION
This PR adds the `moveToIndex` variable to the onDragging callback, which represents the index occupied by the element that is being currently dragged.

This information can be used to animate the list items during dragging (rather than on drop), as you can see in the attached gif.

![animated_drag_sort](https://user-images.githubusercontent.com/1419399/72606128-55d44c00-391e-11ea-85dc-d7fbaa31642b.gif)
 