### PR TITLE
touchCurItem can be null when on start()

### DIFF
--- a/lib/AutoDragSortableView.js
+++ b/lib/AutoDragSortableView.js
@@ -404,13 +404,15 @@ export default class AutoDragSortableView extends Component{
                     useNativeDriver: false,
                 }
             ).start(()=>{
-                this.touchCurItem.ref.setNativeProps({
-                    style: {
-                        zIndex: defaultZIndex,
-                    }
-                })
-                this.changePosition(this.touchCurItem.index,this.touchCurItem.moveToIndex)
-                this.touchCurItem = null
+                if (this.touchCurItem) {
+                    this.touchCurItem.ref.setNativeProps({
+                        style: {
+                            zIndex: defaultZIndex,
+                        }
+                    })
+                    this.changePosition(this.touchCurItem.index,this.touchCurItem.moveToIndex)
+                    this.touchCurItem = null
+                }
             })
             
         }


### PR DESCRIPTION
When doing actions too frequent touchCur Item can be null and accessing ref will generate an error