### PR TITLE
Fix scroll to top on click item before dragging

### DIFF
--- a/lib/AutoDragSortableView.js
+++ b/lib/AutoDragSortableView.js
@@ -643,6 +643,7 @@ export default class AutoDragSortableView extends Component{
                         onLongPress={()=>this.startTouch(index)}
                         onPress={()=>{
                             if (this.props.onClickItem) {
+                                this.isHasMeasure = true
                                 this.props.onClickItem(this.getOriginalData(),item.data,index)
                             }
                         }}>


### PR DESCRIPTION
Bug: on `AutoDragSortableView`, the scroll position gets reset to the top of the page whenever a user clicks on an item before dragging it. This doesn't happen for drag n drop actions.

The fix consists in activating the same flag used in the `startTouch` method, so that the current position is not reset on update.