### PR TITLE
Fix iOS 13 scrollbar bug with scrollIndicatorInsets prop

### DIFF
--- a/Example/app/widget/AutoDragSortableView.js
+++ b/Example/app/widget/AutoDragSortableView.js
@@ -588,6 +588,7 @@ export default class AutoDragSortableView extends Component{
             <ScrollView
                 bounces={false}
                 scrollEventThrottle={1}
+                scrollIndicatorInsets={this.props.scrollIndicatorInsets}
                 ref={(scrollRef)=> this.scrollRef = scrollRef}
                 scrollEnabled = {this.state.scrollEnabled}
                 onScroll={this.onScrollListener}
@@ -692,6 +693,12 @@ AutoDragSortableView.propTypes = {
     autoThrottle: PropTypes.number,
     autoThrottleDuration: PropTypes.number,
     renderHeaderView: PropTypes.element,
+    scrollIndicatorInsets: PropTypes.shape({
+      top: PropTypes.number,
+      left: PropTypes.number,
+      bottom: PropTypes.number,
+      right: PropTypes.number,
+    }),
     headerViewHeight: PropTypes.number,
     renderBottomView: PropTypes.element,
     bottomViewHeight: PropTypes.number,
@@ -713,6 +720,12 @@ AutoDragSortableView.defaultProps = {
     slideDuration: 300,
     autoThrottle: 2,
     autoThrottleDuration: 10,
+    scrollIndicatorInsets: {
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 1,
+    },
     headerViewHeight: 0,
     bottomViewHeight: 0,
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ export { DragSortableView, AutoDragSortableView }
 - **autoThrottleDuration**: PropTypes.number;
 - **renderHeaderView**: PropTypes.element,
 - **headerViewHeight**: PropTypes.number,
+- **scrollIndicatorInsets**: PropTypes.shape({
+  top: PropTypes.number,
+  left: PropTypes.number,
+  bottom: PropTypes.number,
+  right: PropTypes.number
+}),
 - **renderBottomView**: PropTypes.element,
 - **bottomViewHeight**: PropTypes.number,
 

--- a/lib/AutoDragSortableView.js
+++ b/lib/AutoDragSortableView.js
@@ -588,6 +588,7 @@ export default class AutoDragSortableView extends Component{
             <ScrollView
                 bounces={false}
                 scrollEventThrottle={1}
+                scrollIndicatorInsets={this.props.scrollIndicatorInsets}
                 ref={(scrollRef)=> this.scrollRef = scrollRef}
                 scrollEnabled = {this.state.scrollEnabled}
                 onScroll={this.onScrollListener}
@@ -692,6 +693,12 @@ AutoDragSortableView.propTypes = {
     autoThrottle: PropTypes.number,
     autoThrottleDuration: PropTypes.number,
     renderHeaderView: PropTypes.element,
+    scrollIndicatorInsets: PropTypes.shape({
+      top: PropTypes.number,
+      left: PropTypes.number,
+      bottom: PropTypes.number,
+      right: PropTypes.number,
+    }),
     headerViewHeight: PropTypes.number,
     renderBottomView: PropTypes.element,
     bottomViewHeight: PropTypes.number,
@@ -713,6 +720,12 @@ AutoDragSortableView.defaultProps = {
     slideDuration: 300,
     autoThrottle: 2,
     autoThrottleDuration: 10,
+    scrollIndicatorInsets: {
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 1,
+    },
     headerViewHeight: 0,
     bottomViewHeight: 0,
 }

--- a/lib/README.md
+++ b/lib/README.md
@@ -71,6 +71,12 @@ export { DragSortableView, AutoDragSortableView }
 - **autoThrottleDuration**: PropTypes.number;
 - **renderHeaderView**: PropTypes.element,
 - **headerViewHeight**: PropTypes.number,
+- **scrollIndicatorInsets**: PropTypes.shape({
+  top: PropTypes.number,
+  left: PropTypes.number,
+  bottom: PropTypes.number,
+  right: PropTypes.number
+}),
 - **renderBottomView**: PropTypes.element,
 - **bottomViewHeight**: PropTypes.number,
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -36,6 +36,7 @@ interface AutoIProps extends IProps {
   autoThrottleDuration?: number,
   renderHeaderView?: any,
   headerViewHeight?: number,
+  scrollIndicatorInsets?: {top: number, left: number, bottom: number, right: number},
   renderBottomView?: any,
   bottomViewHeight?: number,
 }


### PR DESCRIPTION
This PR provides a solution for [this RN bug](https://github.com/facebook/react-native/issues/26610): the scroll bar in `AutoDragSortableWiew` isn't always fixed to the right margin on iOS 13+ systems. As per suggestion in the aforementioned issue, I added the possibility of setting the prop `scrollIndicatorInsets` for `ListView`, and also set some `defaultProps` to prevent the bug from showing up.