### PR TITLE
Call onDragEnd after changePosition

### DIFF
--- a/lib/AutoDragSortableView.js
+++ b/lib/AutoDragSortableView.js
@@ -405,9 +405,6 @@ export default class AutoDragSortableView extends Component{
             this.setState({
                 scrollEnabled: true
             })
-            if (this.props.onDragEnd) {
-                this.props.onDragEnd(this.touchCurItem.index,this.touchCurItem.moveToIndex)
-            }
             //this.state.dataSource[this.touchCurItem.index].scaleValue.setValue(1)
             Animated.timing(
                 this.state.dataSource[this.touchCurItem.index].scaleValue,
@@ -424,6 +421,9 @@ export default class AutoDragSortableView extends Component{
                         }
                     })
                     this.changePosition(this.touchCurItem.index,this.touchCurItem.moveToIndex)
+                    if (this.props.onDragEnd) {
+                      this.props.onDragEnd(this.touchCurItem.index,this.touchCurItem.moveToIndex)
+                    }
                     this.touchCurItem = null
                 }
             })


### PR DESCRIPTION
Fixing issue https://github.com/mochixuan/react-native-drag-sort/issues/104 by waiting for the internal datasource to get updated by changePosition before calling onDragEnd 