### PR TITLE
Fixing license metadata from ISC -> Apache-2.0

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -22,7 +22,7 @@
     "list"
   ],
   "author": "mochixuan",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {},
   "bugs": {


### PR DESCRIPTION
I noticed the package.json for the code was saying the license was ISC. I've updated that to match the LICENSE file.