### PR TITLE
Using UIManager directly from react-native

### DIFF
--- a/Example/app/widget/AnySizeDragSortableView.js
+++ b/Example/app/widget/AnySizeDragSortableView.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import {
-  NativeModules,
   StyleSheet,
   ScrollView,
   View,
   PanResponder,
   LayoutAnimation,
-  Platform
+  Platform,
+  UIManager
 } from 'react-native';
 const PropTypes = require('prop-types')
 const ANIM_DURATION = 300
-const { UIManager } = NativeModules;
 
 if (Platform.OS === 'android') {
   if (UIManager.setLayoutAnimationEnabledExperimental) {

--- a/lib/AnySizeDragSortableView.js
+++ b/lib/AnySizeDragSortableView.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import {
-  NativeModules,
   StyleSheet,
   ScrollView,
   View,
   PanResponder,
   LayoutAnimation,
-  Platform
+  Platform,
+  UIManager
 } from 'react-native';
 const PropTypes = require('prop-types')
 const ANIM_DURATION = 300
-const { UIManager } = NativeModules;
 
 if (Platform.OS === 'android') {
   if (UIManager.setLayoutAnimationEnabledExperimental) {


### PR DESCRIPTION
Using UIManager directly from react-native instead of from the old NativeModules. Fixes `Cannot read property 'setLayoutAnimationEnabledExperimental' of null` error on Android for recent React Native versions